### PR TITLE
make deprecation warning explicit; fix tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteHilbertTransform"
 uuid = "68cdf181-988b-4042-8999-0b9541c1c3c2"
 authors = ["Mike Petersen <petersen@iap.fr>", "Mathieu Roule <roule@iap.fr>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/Legendre/Legendre.jl
+++ b/src/Legendre/Legendre.jl
@@ -488,7 +488,7 @@ function GetaXi!(FHT::LegendreFHT,
     tabG::AbstractVector{Float64},
     res::Vector{Float64},warnflag::Vector{Float64})
 
-    @warn "FiniteHilbertTransform.GetaXi!: deprecation warning: warnflag is now an integer." maxlog=1
+    @warn "FiniteHilbertTransform.GetaXi!: deprecation warning for v1.2: warnflag is now an integer." maxlog=1
 
     res,warnval = GetaXi!(FHT,tabG,res,0)
     warnflag[1] = warnval

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,7 @@ end
     @test FiniteHilbertTransform.GetaXi(FHT,Gvals)[2] == 0
     # test compatibility version directly
     res = zeros(Float64,Ku)
-    warnflag = zeros(Float64,Ku)
+    warnflag = 0
     @test FiniteHilbertTransform.GetaXi!(FHT,Gvals,res,warnflag)[2][1] == 0
     #
     ϖ = 0.02 + 0.02im


### PR DESCRIPTION
This PR brings `warnflag` in tests in line with current usage, and sets a specific deprecation timeline (`v1.2`) for `warnflag`.